### PR TITLE
INTEG-392: [Unified Search] Searching in IE11 on Windows 7 freezes the b...

### DIFF
--- a/integ-search-portlet/src/main/webapp/js/common/search.js
+++ b/integ-search-portlet/src/main/webapp/js/common/search.js
@@ -723,6 +723,7 @@ window.initSearchSetting = function initSearchSetting(allMsg,alertOk,alertNotOk)
  * 
  */
 window.onImgError = function onImgError(object, errorClasses) {
+  object.onerror = null;
   $(object).parent().empty().append($(document.createElement('i')).addClass(errorClasses));
 }
 


### PR DESCRIPTION
...rowser

Problem analysis
- Onerror action is called continously on IE

Fix description
- Set onerror as null after calling it.