### PR TITLE
INTEG-432: [Unified Search] Missing label of "Tasks" in Filter

### DIFF
--- a/integ-search-service/src/main/resources/conf/portal/configuration.xml
+++ b/integ-search-service/src/main/resources/conf/portal/configuration.xml
@@ -168,7 +168,7 @@
           <properties-param>
              <name>constructor.params</name>
              <property name="searchType" value="task"/>
-             <property name="displayName" value="Tasks in Calendar"/>
+             <property name="displayName" value="Tasks"/>
           </properties-param>
         </init-params>      
       </component-plugin>


### PR DESCRIPTION
Fix description:
- Restore display name of this connector in order to get correct i18n keys.
