### PR TITLE
PLF-6976 PDF preview is broken

### DIFF
--- a/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
+++ b/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
@@ -117,11 +117,6 @@ public class ContentViewerRESTService implements ResourceContainer {
       uiDocViewer.processRender(requestContext);
 
       content = writer.toString();
-      String nodeId = writer.toString().split("PDFJS.pdfFile")[1].split(";")[0].split("/")[5];
-      if (nodeId.contains("\'")) nodeId = nodeId.replace("\'", "");
-      if (!nodeId.equals(uuid)) {
-        content = content.replace(nodeId, uuid);
-      }
 
     } catch (Exception e) {
       LOG.error("Cannot render content of document " + repoName + "/" + workspaceName + "/" + uuid, e);


### PR DESCRIPTION
Revert the way to fix https://jira.exoplatform.org/browse/ECMS-7502
We should not replace a part file path after rendering. It's not good and raise regression bug. 
I propose other fix for this issue in https://github.com/exodev/ecms/pull/248