### PR TITLE
WIKI-1298 : control the wiki page update event type on which activities have to be published

### DIFF
--- a/integ-wiki/integ-wiki-social/pom.xml
+++ b/integ-wiki/integ-wiki-social/pom.xml
@@ -74,5 +74,13 @@
       <artifactId>exo.portal.component.resources</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/integ-wiki/integ-wiki-social/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
+++ b/integ-wiki/integ-wiki-social/src/main/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisher.java
@@ -375,7 +375,7 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
     return isPublic;
   }
   
-  private void saveActivity(String wikiType, String wikiOwner, String pageId, Page page, PageUpdateType activityType) throws WikiException {
+  protected void saveActivity(String wikiType, String wikiOwner, String pageId, Page page, PageUpdateType activityType) throws WikiException {
     try {
       Class.forName("org.exoplatform.social.core.space.spi.SpaceService");
     } catch (ClassNotFoundException e) {
@@ -457,7 +457,13 @@ public class WikiSpaceActivityPublisher extends PageWikiListener {
 
   @Override
   public void postUpdatePage(String wikiType, String wikiOwner, String pageId, Page page, PageUpdateType wikiUpdateType) throws WikiException {
-    if(page != null) {
+    // Generate an activity only in the following cases
+    if(page != null && wikiUpdateType != null
+            && (wikiUpdateType.equals(PageUpdateType.ADD_PAGE)
+            || wikiUpdateType.equals(PageUpdateType.EDIT_PAGE_CONTENT)
+            || wikiUpdateType.equals(PageUpdateType.EDIT_PAGE_TITLE)
+            || wikiUpdateType.equals(PageUpdateType.EDIT_PAGE_CONTENT_AND_TITLE)
+            || wikiUpdateType.equals(PageUpdateType.MOVE_PAGE))) {
       saveActivity(wikiType, wikiOwner, pageId, page, wikiUpdateType);
     }
   }

--- a/integ-wiki/integ-wiki-social/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
+++ b/integ-wiki/integ-wiki-social/src/test/java/org/exoplatform/wiki/ext/impl/WikiSpaceActivityPublisherTest.java
@@ -1,0 +1,43 @@
+package org.exoplatform.wiki.ext.impl;
+
+import org.exoplatform.wiki.mow.api.Page;
+import org.exoplatform.wiki.service.PageUpdateType;
+import org.exoplatform.wiki.service.WikiService;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test class for WikiSpaceActivityPublisher
+ */
+public class WikiSpaceActivityPublisherTest {
+  @Test
+  public void shouldNotCreateActivityWhenUpdateTypeIsNull() throws Exception {
+    // Given
+    WikiService wikiService = Mockito.mock(WikiService.class);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = Mockito.spy(wikiSpaceActivityPublisher);
+    Page page = new Page();
+
+    // When
+    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", page, null);
+
+    // Then
+    Mockito.verify(wikiSpaceActivityPublisherSpy, Mockito.never()).saveActivity("portal", "portal1", "page1", page, null);
+  }
+
+  @Test
+  public void shouldNotCreateActivityWhenUpdateTypeIsPermissionsChange() throws Exception {
+    // Given
+    WikiService wikiService = Mockito.mock(WikiService.class);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisher = new WikiSpaceActivityPublisher(wikiService);
+    WikiSpaceActivityPublisher wikiSpaceActivityPublisherSpy = Mockito.spy(wikiSpaceActivityPublisher);
+    Page page = new Page();
+
+    // When
+    wikiSpaceActivityPublisher.postUpdatePage("portal", "portal1", "page1", page, PageUpdateType.EDIT_PAGE_PERMISSIONS);
+
+    // Then
+    Mockito.verify(wikiSpaceActivityPublisherSpy, Mockito.never()).saveActivity("portal", "portal1", "page1", page, null);
+  }
+
+}


### PR DESCRIPTION
This PR filter the wiki activities update on a pre-defined list of event type to have a good control on authorized event types.
And since the spec does not mention activity update when wiki page permissions are changed (https://community.exoplatform.com/portal/g/:spaces:platform_4/platform_4/wiki/Activity_Types), this event is filtered.