### PR TITLE
SOC-5659 : do not escape content comment since it is already escaped by ckeditor and we want to interpret HTML

### DIFF
--- a/integ-ecms/integ-ecms-social/src/main/resources/groovy/ecm/social-integration/plugin/space/ContentUIActivity.gtmpl
+++ b/integ-ecms/integ-ecms-social/src/main/resources/groovy/ecm/social-integration/plugin/space/ContentUIActivity.gtmpl
@@ -30,7 +30,6 @@
   import org.exoplatform.social.core.service.LinkProvider;
   import org.apache.commons.lang.StringUtils;
   import org.apache.commons.lang.StringEscapeUtils;
-  import org.exoplatform.wcm.webui.reader.ContentReader;
   //ECMS import BEGIN
   import org.exoplatform.wcm.ext.component.activity.ContentPresentation;
   import org.exoplatform.services.jcr.util.Text;
@@ -507,7 +506,6 @@
                   commentMessage = commentBuffer.toString();
               } else {
                 commentMessage = it.title;
-                commentMessage = ContentReader.simpleEscapeHtml(commentMessage);
               }
 
               commentPostedTime = uicomponent.getPostedTimeString(_ctx, it.postedTime);


### PR DESCRIPTION
The comments of content activities are escaped, which leads to displaying the HTML tags. As for files activities, we want to interpret HTML (and malicious tags like <script> is already escaped by ckeditor), so this PR removes the HTML escaping.