### PR TITLE
SOC-5963 : do not append post id to the post url since it is already in the post link

### DIFF
--- a/integ-forum/integ-forum-social/src/main/java/org/exoplatform/forum/ext/activity/ForumActivityBuilder.java
+++ b/integ-forum/integ-forum-social/src/main/java/org/exoplatform/forum/ext/activity/ForumActivityBuilder.java
@@ -90,7 +90,7 @@ public class ForumActivityBuilder {
     Map<String, String> templateParams = new HashMap<String, String>();
     
     templateParams.put(POST_ID_KEY, post.getId());
-    templateParams.put(POST_LINK_KEY, post.getLink() + "/" + post.getId());
+    templateParams.put(POST_LINK_KEY, post.getLink());
     templateParams.put(POST_NAME_KEY, post.getName());
     templateParams.put(POST_OWNER_KEY, post.getOwner());
     //

--- a/integ-forum/integ-forum-social/src/test/java/org/exoplatform/forum/ext/activity/AbstractActivityTypeTest.java
+++ b/integ-forum/integ-forum-social/src/test/java/org/exoplatform/forum/ext/activity/AbstractActivityTypeTest.java
@@ -220,6 +220,7 @@ public abstract class AbstractActivityTypeTest extends BaseExoTestCase {
     post.setIsHidden(false);
     post.setIsWaiting(false);
     post.setPath("forumCategory123/forum123/topic123/" + post.getId());
+    post.setLink("http://localhost:8080/portal/intranet/forum/topic123/" + post.getId());
     topic.setPostCount(topic.getPostCount() + 1);
     return post;
   }

--- a/integ-forum/integ-forum-social/src/test/java/org/exoplatform/forum/ext/activity/PostActivityTest.java
+++ b/integ-forum/integ-forum-social/src/test/java/org/exoplatform/forum/ext/activity/PostActivityTest.java
@@ -22,6 +22,8 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
 
+import static org.exoplatform.forum.ext.activity.ForumActivityBuilder.POST_LINK_KEY;
+
 /**
  * Created by The eXo Platform SAS
  * Author : thanh_vucong
@@ -49,6 +51,7 @@ public class PostActivityTest extends AbstractActivityTypeTest {
     ForumActivityContext ctx = ForumActivityContext.makeContextForAddPost(post);
     ExoSocialActivity comment = ForumActivityBuilder.createActivityComment(post, ctx);
     assertPostTitle(comment, postContent);
+    assertEquals(comment.getTemplateParams().get(POST_LINK_KEY), post.getLink());
   }
 
   public void testTriggerAddPostTwice() throws Exception {
@@ -85,6 +88,7 @@ public class PostActivityTest extends AbstractActivityTypeTest {
     comment = task.processComment(ctx, comment);
     assertPostTitle(comment, postContent);
     assertNumberOfReplies(topicActivity, 1);
+    assertEquals(comment.getTemplateParams().get(POST_LINK_KEY), post.getLink());
   }
   
   public void testUpdateTopic() throws Exception {
@@ -95,6 +99,7 @@ public class PostActivityTest extends AbstractActivityTypeTest {
     ForumActivityContext ctx = ForumActivityContext.makeContextForAddPost(post);
     ExoSocialActivity comment = ForumActivityBuilder.createActivityComment(post, ctx);
     assertPostTitle(comment, postContent);
+    assertEquals(comment.getTemplateParams().get(POST_LINK_KEY), post.getLink());
   }
   
   public void testUpdateTopicWithJob() throws Exception {
@@ -112,11 +117,13 @@ public class PostActivityTest extends AbstractActivityTypeTest {
     //Comment associated with this post exist --> update
     comment = task.processComment(ctx, comment);
     assertPostTitle(comment, "Edited his reply to: edited post content");
-    
+    assertEquals(comment.getTemplateParams().get(POST_LINK_KEY), post.getLink());
+
     //Comment associated with this post has been deleted --> add new
     comment = task.processComment(ctx, null);
     assertPostTitle(comment, "Edited his reply to: edited post content");
-    
+    assertEquals(comment.getTemplateParams().get(POST_LINK_KEY), post.getLink());
+
     //Case of post with multi-lines, 3 firsts lines will be used
     updatePostContent(post, "edited post content1\n2\n3\n4\n5");
     
@@ -129,9 +136,11 @@ public class PostActivityTest extends AbstractActivityTypeTest {
     //Comment associated with this post exist --> update
     comment = task.processComment(ctx, comment);
     assertPostTitle(comment, "Edited his reply to: edited post content1<br/>2<br/>3...");
+    assertEquals(comment.getTemplateParams().get(POST_LINK_KEY), post.getLink());
     
     //Comment associated with this post has been deleted --> add new
     comment = task.processComment(ctx, null);
     assertPostTitle(comment, "Edited his reply to: edited post content1<br/>2<br/>3...");
+    assertEquals(comment.getTemplateParams().get(POST_LINK_KEY), post.getLink());
   }
 }


### PR DESCRIPTION
The issue is that the URL contains the post id twice (for example http://localhost:8080/portal/intranet/forum/topic/topice9c099b97f00010122b4de0f1c565038/poste9c194667f0001011c2f1b885ba64fa0/poste9c194667f0001011c2f1b885ba64fa0 instead of http://localhost:8080/portal/intranet/forum/topic/topice9c099b97f00010122b4de0f1c565038/poste9c194667f0001011c2f1b885ba64fa0).
post.getLink() already returns the right URL (with the post id appended), so no need to append it again.