### PR TITLE
SOC-5983 : fix wrong HTML structure for Link activities (with embedded HTML)

### DIFF
--- a/integ-ecms/integ-ecms-social/src/main/resources/groovy/ecm/social-integration/plugin/link/UILinkActivityComposer.gtmpl
+++ b/integ-ecms/integ-ecms-social/src/main/resources/groovy/ecm/social-integration/plugin/link/UILinkActivityComposer.gtmpl
@@ -172,8 +172,7 @@ link
             <% if (images != null && images.size() > 0) { %>
 			      <span class="uiCheckbox"><input id="ThumbnailCheckbox" type="checkbox" class="checkbox" /><span>$noThumbnail</span></span>
 			      <% } %>
-          </div>
-			</div>
+		  </div>
 		<%
       }
     %>


### PR DESCRIPTION
The HTML is not correct when linking a video or any other content which embeds HTML (slideshare, ...). This PR removes the extra div.