### PR TITLE
INTEG-488 :Preview of contents is not localized

### DIFF
--- a/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
+++ b/integ-ecms/integ-ecms-social/src/main/java/org/exoplatform/wcm/ext/component/document/service/ContentViewerRESTService.java
@@ -116,7 +116,7 @@ public class ContentViewerRESTService implements ResourceContainer {
 
       ControllerContext controllerContext = new ControllerContext(webAppController, webAppController.getRouter(), request, response, null);
       PortalApplication application = webAppController.getApplication(PortalApplication.PORTAL_APPLICATION_ID);
-      PortalRequestContext requestContext = new PortalRequestContext(application, controllerContext, org.exoplatform.portal.mop.SiteType.PORTAL.toString(), "", "", null);
+      PortalRequestContext requestContext = new PortalRequestContext(application, controllerContext, org.exoplatform.portal.mop.SiteType.PORTAL.toString(), "", "", request.getLocale());
       WebuiRequestContext.setCurrentInstance(requestContext);
       UIPortalApplication uiApplication = new UIPortalApplication();
       uiApplication.setCurrentSite(new UIPortal());


### PR DESCRIPTION
the main issue that we are using rest service to render the content preview, so we are manually creating
webui context by setting the writer and the instance with the default Locale.
It's impossible to get the current local from the rest context.
Furthermore only portal resources bundle will be available at this level, from the reported issue we are trying to use portlet resource bundle "Category.view.label " so for me it's should be normal behavior to get this issue.
As we are using the same template that will be rendered in both file explorer context and the activity context (from the rest service) to get around that and avoid perf issue by loading all the template resources bundle, in the customer extension we can create these bundles at portal level