### PR TITLE
Fix/soc 6132

### DIFF
--- a/integ-calendar/integ-calendar-social/src/main/resources/groovy/cs/social-integration/plugin/space/CalendarUIActivity.gtmpl
+++ b/integ-calendar/integ-calendar-social/src/main/resources/groovy/cs/social-integration/plugin/space/CalendarUIActivity.gtmpl
@@ -45,7 +45,6 @@
   def labelActivityHasBeenDeleted = _ctx.appRes("UIActivity.label.Activity_Has_Been_Deleted");
   def activity = uicomponent.getActivity();
   def activityDeletable = uicomponent.isActivityDeletable();
-  def activityEditable = uicomponent.isActivityEditable(activity);
   def activityCommentAndLikable = uicomponent.isActivityCommentAndLikable();
   def streamOwner = activity.getStreamOwner();
   def event = uicomponent.event ;
@@ -246,7 +245,7 @@
 					<span class="arrowLeft"></span>
                 <!--div class="pull-right"-->
 			    <%
-			  		if(activityEditable || activityDeletable) {
+			  		if( activityDeletable) {
 			    %>
                     <div id="dropDownEditActivity${activity.id}" class="btn-group uiDropdownWithIcon actLink hidden-phone hidden-tablet">
                         <div class="dropdown-toggle" data-toggle="dropdown">
@@ -254,17 +253,11 @@
                             </i>
                         </div>
                         <ul class="dropdown-menu pull-right" role="menu">
-							<% if(activityEditable) {%>
-                            <!--li>
-                                <a id="EditActivitylink${activity.id}" class="" data-edit-activity="${activity.id}" data-placement="bottom" href="javascript:void(0)">${labelEdit}</a>
-                            </li-->
                             <%
-							}
 							if (activityDeletable) {
                             %>
                             <li>
                                 <a href="javascript:void(0)" data-confirm="$labelToDeleteThisActivity" data-caption="$captionConfirmation" data-close="$labelClosebutton" data-ok="$labelConfirmbutton"  data-delete="<%=uicomponent.event("DeleteActivity", uicomponent.getId(), "");%>" class="controllDelete" id="DeleteActivityButton${activity.id}">${labelDelete}</a>
-
                             </li>
                             <%}%>
                         </ul>

--- a/integ-calendar/integ-calendar-social/src/main/resources/groovy/cs/social-integration/plugin/space/CalendarUIActivity.gtmpl
+++ b/integ-calendar/integ-calendar-social/src/main/resources/groovy/cs/social-integration/plugin/space/CalendarUIActivity.gtmpl
@@ -245,7 +245,7 @@
 					<span class="arrowLeft"></span>
                 <!--div class="pull-right"-->
 			    <%
-			  		if( activityDeletable) {
+			  		if(activityDeletable) {
 			    %>
                     <div id="dropDownEditActivity${activity.id}" class="btn-group uiDropdownWithIcon actLink hidden-phone hidden-tablet">
                         <div class="dropdown-toggle" data-toggle="dropdown">

--- a/integ-ecms/integ-ecms-social/src/main/resources/groovy/ecm/social-integration/plugin/space/ContentUIActivity.gtmpl
+++ b/integ-ecms/integ-ecms-social/src/main/resources/groovy/ecm/social-integration/plugin/space/ContentUIActivity.gtmpl
@@ -45,7 +45,6 @@
   def labelActivityHasBeenDeleted = _ctx.appRes("UIActivity.label.Activity_Has_Been_Deleted");
   def activity = uicomponent.getActivity();
   def activityDeletable = uicomponent.isActivityDeletable();
-  def activityEditable = uicomponent.isActivityEditable(activity);
   def activityCommentAndLikable = uicomponent.isActivityCommentAndLikable();
   def streamOwner = activity.getStreamOwner();
   def currentNode = uicomponent.getContentNode();
@@ -305,7 +304,7 @@
 					<span class="arrowLeft"></span>
                 <!--div class="pull-right"-->
 			    <%
-			  		if(activityEditable || activityDeletable ) {
+			  		if( activityDeletable ) {
 			    %>
                     <div id="dropDownEditActivity${activity.id}" class="btn-group uiDropdownWithIcon actLink hidden-phone hidden-tablet">
                         <div class="dropdown-toggle" data-toggle="dropdown">
@@ -313,17 +312,11 @@
                             </i>
                         </div>
                         <ul class="dropdown-menu pull-right" role="menu">
-							<% if(activityEditable) {%>
-                            <!--li>
-                                <a id="EditActivitylink${activity.id}" class="" data-edit-activity="${activity.id}" data-placement="bottom" href="javascript:void(0)">${labelEdit}</a>
-                            </li-->
                             <%
-							}
 							if (activityDeletable) {
                             %>
                             <li>
                                 <a href="javascript:void(0)" data-confirm="$labelToDeleteThisActivity" data-caption="$captionConfirmation" data-close="$labelClosebutton" data-ok="$labelConfirmbutton"  data-delete="<%=uicomponent.event("DeleteActivity", uicomponent.getId(), "");%>" class="controllDelete" id="DeleteActivityButton${activity.id}">${labelDelete}</a>
-
                             </li>
                             <%}%>
                         </ul>

--- a/integ-forum/integ-forum-social/src/main/resources/groovy/forum/social-integration/plugin/space/ForumUIActivity.gtmpl
+++ b/integ-forum/integ-forum-social/src/main/resources/groovy/forum/social-integration/plugin/space/ForumUIActivity.gtmpl
@@ -41,7 +41,6 @@
   def labelActivityHasBeenDeleted = _ctx.appRes("UIActivity.label.Activity_Has_Been_Deleted");
   def activity = uicomponent.getActivity();
   def activityDeletable = uicomponent.isActivityDeletable();
-  def activityEditable = uicomponent.isActivityEditable(activity);
   def activityCommentAndLikable = uicomponent.isActivityCommentAndLikable();
   def activityCommentable = uicomponent.isActivityCommentable();
   def streamOwner = activity.getStreamOwner();
@@ -241,7 +240,7 @@
 					<span class="arrowLeft"></span>
                 <!--div class="pull-right"-->
 			    <%
-			  		if(activityEditable || activityDeletable) {
+			  		if(activityDeletable) {
 			    %>
                     <div id="dropDownEditActivity${activity.id}" class="btn-group uiDropdownWithIcon actLink hidden-phone hidden-tablet">
                         <div class="dropdown-toggle" data-toggle="dropdown">
@@ -249,17 +248,11 @@
                             </i>
                         </div>
                         <ul class="dropdown-menu pull-right" role="menu">
-							<% if(activityEditable) {%>
-                            <!--li>
-                                <a id="EditActivitylink${activity.id}" class="" data-edit-activity="${activity.id}" data-placement="bottom" href="javascript:void(0)">${labelEdit}</a>
-                            </li-->
                             <%
-							}
 							if (activityDeletable) {
                             %>
                             <li>
                                 <a href="javascript:void(0)" data-confirm="$labelToDeleteThisActivity" data-caption="$captionConfirmation" data-close="$labelClosebutton" data-ok="$labelConfirmbutton"  data-delete="<%=uicomponent.event("DeleteActivity", uicomponent.getId(), "");%>" class="controllDelete" id="DeleteActivityButton${activity.id}">${labelDelete}</a>
-
                             </li>
                             <%}%>
                         </ul>

--- a/integ-forum/integ-forum-social/src/main/resources/groovy/forum/social-integration/plugin/space/PollUIActivity.gtmpl
+++ b/integ-forum/integ-forum-social/src/main/resources/groovy/forum/social-integration/plugin/space/PollUIActivity.gtmpl
@@ -37,7 +37,6 @@
   def labelActivityHasBeenDeleted = _ctx.appRes("UIActivity.label.Activity_Has_Been_Deleted");
   def activity = uicomponent.getActivity();
   def activityDeletable = uicomponent.isActivityDeletable();
-  def activityEditable = uicomponent.isActivityEditable(activity);
   def activityCommentAndLikable = uicomponent.isActivityCommentAndLikable();
   def streamOwner = activity.getStreamOwner();
   String viewActivityTip = _ctx.appRes("UIActivity.msg.ViewActivity");
@@ -246,7 +245,7 @@
 				<span class="arrowLeft"></span>
                 <!--div class="pull-right"-->
 			    <%
-			  		if(activityEditable || activityDeletable ) {
+			  		if( activityDeletable ) {
 			    %>
                     <div id="dropDownEditActivity${activity.id}" class="btn-group uiDropdownWithIcon actLink hidden-phone hidden-tablet">
                         <div class="dropdown-toggle" data-toggle="dropdown">
@@ -254,17 +253,11 @@
                             </i>
                         </div>
                         <ul class="dropdown-menu pull-right" role="menu">
-							<% if(activityEditable) {%>
-                            <!--li>
-                                <a id="EditActivitylink${activity.id}" class="" data-edit-activity="${activity.id}" data-placement="bottom" href="javascript:void(0)">${labelEdit}</a>
-                            </li-->
                             <%
-							}
 							if (activityDeletable) {
                             %>
                             <li>
                                 <a href="javascript:void(0)" data-confirm="$labelToDeleteThisActivity" data-caption="$captionConfirmation" data-close="$labelClosebutton" data-ok="$labelConfirmbutton"  data-delete="<%=uicomponent.event("DeleteActivity", uicomponent.getId(), "");%>" class="controllDelete" id="DeleteActivityButton${activity.id}">${labelDelete}</a>
-
                             </li>
                             <%}%>
                         </ul>

--- a/integ-wiki/integ-wiki-social/src/main/resources/groovy/wiki/social-integration/plugin/space/WikiUIActivity.gtmpl
+++ b/integ-wiki/integ-wiki-social/src/main/resources/groovy/wiki/social-integration/plugin/space/WikiUIActivity.gtmpl
@@ -39,7 +39,6 @@
   def labelActivityHasBeenDeleted = _ctx.appRes("UIActivity.label.Activity_Has_Been_Deleted");
   def activity = uicomponent.getActivity();
   def activityDeletable = uicomponent.isActivityDeletable();
-  def activityEditable = uicomponent.isActivityEditable(activity);
   def activityCommentAndLikable = uicomponent.isActivityCommentAndLikable();
   def streamOwner = activity.getStreamOwner();
   String viewActivityTip = _ctx.appRes("UIActivity.msg.ViewActivity");
@@ -244,7 +243,7 @@
 
                     <!--div class="pull-right"-->
                     <%
-                      if(activityEditable || activityDeletable) {
+                      if(activityDeletable) {
                     %>
                         <div id="dropDownEditActivity${activity.id}" class="btn-group uiDropdownWithIcon actLink hidden-phone hidden-tablet">
                             <div class="dropdown-toggle" data-toggle="dropdown">
@@ -252,17 +251,11 @@
                                 </i>
                             </div>
                             <ul class="dropdown-menu pull-right" role="menu">
-                        <% if(activityEditable) {%>
-                              <!--li>
-                                  <a id="EditActivitylink${activity.id}" class="" data-edit-activity="${activity.id}" data-placement="bottom" href="javascript:void(0)">${labelEdit}</a>
-                              </li-->
                         <%
-                           }
                            if (activityDeletable) {
                         %>
                               <li>
                                   <a href="javascript:void(0)" data-confirm="$labelToDeleteThisActivity" data-caption="$captionConfirmation" data-close="$labelClosebutton" data-ok="$labelConfirmbutton"  data-delete="<%=uicomponent.event("DeleteActivity", uicomponent.getId(), "");%>" class="controllDelete" id="DeleteActivityButton${activity.id}">${labelDelete}</a>
-
                               </li>
                         <%}%>
                             </ul>


### PR DESCRIPTION
When create a new space, the activity created automatically should be not editable.
The solution is to disable Edit button in Space Activity Template.
The comments related to a space which are created automatically like (space renamed, member joined a space, space description updated ..) shall also be not editable.
The solution is to specify the different cases in which the comment is considered as automatically created in the service isActivityEditable of the ActivityManager class file.